### PR TITLE
deprecate anndata for R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,9 +30,9 @@ Description: A 'reticulate' wrapper for the Python package 'anndata'.
     Provides a scalable way of keeping track of data and learned
     annotations.  Used to read from and write to the h5ad file format.
     This package is superseded by 'anndataR'
-    <https://anndataR.scverse.org>, which provides a pure R
-    implementation of the 'AnnData' data structure without requiring Python,
-    along with conversion to/from 'SingleCellExperiment' and 'Seurat' objects.
+    <https://anndataR.scverse.org>, which provides native R backends for
+    the 'AnnData' data structure, along with conversion to/from
+    'SingleCellExperiment' and 'Seurat' objects.
 License: MIT + file LICENSE
 URL: https://anndata.dynverse.org, https://github.com/dynverse/anndata
 BugReports: https://github.com/dynverse/anndata/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: anndata
-Title: 'anndata' for R
-Version: 0.8.0
+Title: 'anndata' for R (Superseded)
+Version: 0.9.0
 Authors@R:
     c(person(given = "Philipp",
              family = "Angerer",
@@ -29,6 +29,10 @@ Authors@R:
 Description: A 'reticulate' wrapper for the Python package 'anndata'.
     Provides a scalable way of keeping track of data and learned
     annotations.  Used to read from and write to the h5ad file format.
+    This package is superseded by 'anndataR'
+    <https://anndataR.scverse.org>, which provides a pure R
+    implementation of the 'AnnData' data structure without requiring Python,
+    along with conversion to/from 'SingleCellExperiment' and 'Seurat' objects.
 License: MIT + file LICENSE
 URL: https://anndata.dynverse.org, https://github.com/dynverse/anndata
 BugReports: https://github.com/dynverse/anndata/issues
@@ -49,7 +53,7 @@ Suggests:
     rmarkdown
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/reticulate:
   list(
     packages = list(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# anndata 0.9.0
+
+* SUPERSEDED: This package is superseded by `anndataR` on Bioconductor
+  (<https://anndataR.scverse.org>). `anndataR` provides a pure R
+  implementation of the `AnnData` data structure without requiring Python, along
+  with native `.h5ad` file reading/writing and conversion to/from
+  `SingleCellExperiment` and `Seurat` objects. A migration guide is available
+  at `vignette("migration_to_anndataR", package = "anndata")`.
+
 # anndata 0.8.0
 
 * FUNCTIONALITY: Added support for `read_zarr()` and `write_zarr()` (PR #33).

--- a/R/class_anndata.R
+++ b/R/class_anndata.R
@@ -79,6 +79,12 @@
 #' @param obsp Pairwise annotation of observations, a mutable mapping with array-like values.
 #' @param varp Pairwise annotation of observations, a mutable mapping with array-like values.
 #'
+#' @section Superseded:
+#' `r lifecycle::badge('superseded')`
+#' This function is superseded by [`anndataR::AnnData()`](https://anndataR.scverse.org/reference/AnnData.html)
+#' in the [anndataR](https://anndataR.scverse.org) package.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
+#'
 #' @export
 #'
 #' @seealso [read_h5ad()] [read_csv()] [read_excel()] [read_hdf()] [read_loom()] [read_mtx()] [read_text()] [read_umi_tools()] [write_h5ad()] [write_csvs()] [write_loom()]

--- a/R/concat.R
+++ b/R/concat.R
@@ -1,6 +1,13 @@
 #' @title concat
 #'
-#' @description Concatenates AnnData objects along an axis.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Concatenates AnnData objects along an axis.
+#'
+#' @section Superseded:
+#' This function is superseded. The [anndataR](https://anndataR.scverse.org)
+#' package supports working with `AnnData` objects natively in R without Python.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @details See the `concatenation` section in the docs for a more in-depth description.
 #'

--- a/R/package.R
+++ b/R/package.R
@@ -1,16 +1,27 @@
 #' anndata - Annotated Data
 #'
+#' `r lifecycle::badge('superseded')`
+#'
+#' **This package is superseded by [anndataR](https://anndataR.scverse.org).**
+#' `anndataR` provides a pure R implementation of the `AnnData` data structure
+#' with native `h5ad` file reading/writing and conversion to/from
+#' `SingleCellExperiment` and `Seurat` objects. Please consider migrating;
+#' see `vignette("migration_to_anndataR", package = "anndata")` for guidance.
+#'
+#' If you already have Python `anndata` installed, `anndataR`'s `ReticulateAnnData`
+#' backend lets you keep using your existing Python environment while gaining access
+#' to `anndataR`'s unified interface. The native `InMemoryAnnData` and `HDF5AnnData`
+#' backends (no Python required) are preferred for new workflows.
+#'
 #' `anndata` provides a scalable way of keeping track of data
 #' and learned annotations, and can be used to read from and write to the h5ad
 #' file format. `AnnData()` stores a data matrix `X` together with annotations
 #' of observations `obs` (`obsm`, `obsp`), variables `var` (`varm`, `varp`),
 #' and unstructured annotations `uns`.
 #'
-#' This package is, in essense, an R wrapper for the similarly named Python package
+#' This package is an R wrapper for the similarly named Python package
 #' [`anndata`](https://anndata.readthedocs.io/en/latest/), with some added functionality
 #' to support more R-like syntax.
-#' The version number of the anndata R package is synced
-#' with the version number of the python version.
 #'
 #' Check out `?anndata` for a full list of the functions provided by this package.
 #'

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -1,6 +1,13 @@
 #' @title read_csv
 #'
-#' @description Read `.csv` file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.csv` file.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @details Same as [read_text()] but with default delimiter `','`.
 #'

--- a/R/read_excel.R
+++ b/R/read_excel.R
@@ -1,6 +1,13 @@
 #' @title read_excel
 #'
-#' @description Read `.xlsx` (Excel) file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.xlsx` (Excel) file.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @details Assumes that the first columns stores the row names and the first row the
 #' column names.

--- a/R/read_h5ad.R
+++ b/R/read_h5ad.R
@@ -1,6 +1,14 @@
 #' @title read_h5ad
 #'
-#' @description Read `.h5ad`-formatted hdf5 file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.h5ad`-formatted hdf5 file.
+#'
+#' @section Superseded:
+#' This function is superseded by [`anndataR::read_h5ad()`](https://anndataR.scverse.org/reference/read_h5ad.html)
+#' in the [anndataR](https://anndataR.scverse.org) package,
+#' which reads `.h5ad` files natively without requiring Python.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @param filename File name of data file.
 #' @param backed If `'r'`, load `~anndata.AnnData` in `backed` mode instead of fully loading it into memory (`memory` mode). If you want to modify backed attributes of the AnnData object, you need to choose `'r+'`.

--- a/R/read_hdf.R
+++ b/R/read_hdf.R
@@ -1,6 +1,13 @@
 #' @title read_hdf
 #'
-#' @description Read `.h5` (hdf5) file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.h5` (hdf5) file.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @details Note: Also looks for fields `row_names` and `col_names`.
 #'

--- a/R/read_loom.R
+++ b/R/read_loom.R
@@ -1,6 +1,13 @@
 #' @title read_loom
 #'
-#' @description Read `.loom`-formatted hdf5 file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.loom`-formatted hdf5 file.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @details This reads the whole file into memory. Beware that you have to explicitly state when you want to read the file as
 #' sparse data.

--- a/R/read_mtx.R
+++ b/R/read_mtx.R
@@ -1,6 +1,13 @@
 #' @title read_mtx
 #'
-#' @description Read `.mtx` file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.mtx` file.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @param filename The filename.
 #' @param dtype Numpy data type.

--- a/R/read_text.R
+++ b/R/read_text.R
@@ -1,6 +1,13 @@
 #' @title read_text
 #'
-#' @description Read `.txt`, `.tab`, `.data` (text) file.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read `.txt`, `.tab`, `.data` (text) file.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @details Same as [read_csv()] but with default delimiter `NULL`.
 #'

--- a/R/read_umi_tools.R
+++ b/R/read_umi_tools.R
@@ -1,6 +1,13 @@
 #' @title read_umi_tools
 #'
-#' @description Read a gzipped condensed count matrix from umi_tools.
+#' @description
+#' `r lifecycle::badge('superseded')`
+#' Read a gzipped condensed count matrix from umi_tools.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @param filename File name to read from.
 #' @param dtype Numpy data type.

--- a/R/read_zarr.R
+++ b/R/read_zarr.R
@@ -1,5 +1,12 @@
 #' Read from a hierarchical Zarr array store.
 #'
+#' `r lifecycle::badge('superseded')`
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
+#'
 #' @param store The filename, a MutableMapping, or a Zarr storage class.
 #'
 #' @export

--- a/R/write_csvs.R
+++ b/R/write_csvs.R
@@ -1,6 +1,13 @@
 #' Write annotation to .csv files.
 #'
+#' `r lifecycle::badge('superseded')`
+#'
 #' It is not possible to recover the full AnnData from these files. Use [write_h5ad()] for this.
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @param anndata An [AnnData()] object
 #' @param dirname Name of the directory to which to export.

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -1,7 +1,15 @@
 #' Write .h5ad-formatted hdf5 file.
 #'
+#' `r lifecycle::badge('superseded')`
+#'
 #' Generally, if you have sparse data that are stored as a dense matrix, you can
 #' dramatically improve performance and reduce disk space by converting to a csr_matrix:
+#'
+#' @section Superseded:
+#' This function is superseded by [`anndataR::write_h5ad()`](https://anndataR.scverse.org/reference/write_h5ad.html)
+#' in the [anndataR](https://anndataR.scverse.org) package,
+#' which writes `.h5ad` files natively without requiring Python.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
 #'
 #' @param anndata An [AnnData()] object
 #' @param filename Filename of data file. Defaults to backing file.

--- a/R/write_loom.R
+++ b/R/write_loom.R
@@ -1,5 +1,12 @@
 #' Write .loom-formatted hdf5 file.
 #'
+#' `r lifecycle::badge('superseded')`
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
+#'
 #' @param anndata An [AnnData()] object
 #' @param filename The filename.
 #' @param write_obsm_varm Whether or not to also write the varm and obsm.

--- a/R/write_zarr.R
+++ b/R/write_zarr.R
@@ -1,5 +1,12 @@
 #' Write a hierarchical Zarr array store.
 #'
+#' `r lifecycle::badge('superseded')`
+#'
+#' @section Superseded:
+#' This function is superseded. Please use [anndataR](https://anndataR.scverse.org)
+#' for reading and working with `AnnData` objects in R.
+#' See `vignette("migration_to_anndataR", package = "anndata")` for migration guidance.
+#'
 #' @param anndata An [AnnData()] object
 #' @param store The filename, a MutableMapping, or a Zarr storage class.
 #' @param chunks Chunk shape.

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,29 +17,30 @@ set.seed(1)
 [![CRAN Downloads](https://cranlogs.r-pkg.org/badges/anndata)](https://cran.r-project.org/package=anndata)
 [![R-CMD-check](https://github.com/dynverse/anndata/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/dynverse/anndata/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://app.codecov.io/gh/dynverse/anndata/branch/main/graph/badge.svg)](https://app.codecov.io/gh/dynverse/anndata?branch=main)
+[![Lifecycle: superseded](https://img.shields.io/badge/lifecycle-superseded-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#superseded)
 <!-- badges: end -->
 
-[`anndata`](https://anndata.readthedocs.io/en/latest/) is a commonly used Python package 
-for keeping track of data and learned annotations, and can be used to read from and write to the h5ad 
-file format. It is also the main data format used in the scanpy python package [@wolf_scanpylargescalesinglecell_2018].
+> **⚠️ This package is superseded by [anndataR](https://anndataR.scverse.org).**
+>
+> `anndataR` provides a pure R implementation of the `AnnData` data structure — no Python
+> required. It reads and writes `.h5ad` files natively and supports conversion to/from
+> `SingleCellExperiment` and `Seurat` objects. New users should install `anndataR` from
+> Bioconductor instead:
+>
+> ```r
+> BiocManager::install("anndataR")
+> ```
+>
+> Existing users of `anndata` can follow the
+> [migration guide](https://anndata.dynverse.org/articles/migration_to_anndataR.html)
+> for guidance on switching to `anndataR`.
 
-![](https://raw.githubusercontent.com/dynverse/anndata/master/man/readme_files/anndata_for_r.png)
-
-However, using scanpy/anndata in R can be a major hassle. When trying to read an h5ad file,
-R users could approach this problem in one of two ways. A) You could read in the file manually
-(since it's an H5 file), but this involves a lot of manual work and a lot of understanding
-on how the h5ad and H5 file formats work (also, expect major headaches from cryptic hdf5r bugs).
-Or B) interact with scanpy and anndata through reticulate, but run into issues converting
-some of the python objects into R.
-
-We recently published [`anndata`](https://cran.r-project.org/package=anndata) on CRAN,
-which is a reticulate wrapper for the Python package -- with some syntax sprinkled on top to make
-R users feel more at home. 
-
-anndata for R is still under active development at [github.com/dynverse/anndata](https://github.com/dynverse/anndata). 
-If you encounter any issues, feel free to post an issue on GitHub!
+`anndata` for R is a `reticulate` wrapper for the Python `anndata` package.
 
 ## Installation
+
+> **Note:** New projects should use [anndataR](https://anndataR.scverse.org) instead.
+> See the [migration guide](https://anndata.dynverse.org/articles/migration_to_anndataR.html).
 
 You can install `anndata` for R from CRAN as follows:
 
@@ -92,8 +93,8 @@ walk(
 
 ## Future work
 
-In some cases, this package may still act more like a Python package rather than an R package.
-Some more helper functions and helper classes need to be defined in order to fully encapsulate
-`AnnData()` objects. Examples are `ad$chunked_X(...)`, backed file modes, `read_zarr()` and `ad$write_zarr()`.
+This package is no longer under active development as it has been superseded by
+[anndataR](https://anndataR.scverse.org). Bug fixes may still be
+applied, but no new features are planned.
 
 ## References

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ set.seed(1)
 
 > **⚠️ This package is superseded by [anndataR](https://anndataR.scverse.org).**
 >
-> `anndataR` provides a pure R implementation of the `AnnData` data structure — no Python
+> `anndataR` provides a pure R implementation of the `AnnData` data structure with no Python
 > required. It reads and writes `.h5ad` files natively and supports conversion to/from
 > `SingleCellExperiment` and `Seurat` objects. New users should install `anndataR` from
 > Bioconductor instead:

--- a/README.md
+++ b/README.md
@@ -6,38 +6,39 @@
 [![CRAN](https://www.r-pkg.org/badges/version/anndata)](https://cran.r-project.org/package=anndata)
 [![CRAN
 Downloads](https://cranlogs.r-pkg.org/badges/anndata)](https://cran.r-project.org/package=anndata)
-[![R-CMD-check](https://github.com/dynverse/anndata/workflows/R-CMD-check/badge.svg)](https://github.com/dynverse/anndata/actions)
+[![R-CMD-check](https://github.com/dynverse/anndata/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/dynverse/anndata/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://app.codecov.io/gh/dynverse/anndata/branch/main/graph/badge.svg)](https://app.codecov.io/gh/dynverse/anndata?branch=main)
+[![Lifecycle:
+superseded](https://img.shields.io/badge/lifecycle-superseded-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#superseded)
 <!-- badges: end -->
 
-[`anndata`](https://anndata.readthedocs.io/en/latest/) is a commonly
-used Python package for keeping track of data and learned annotations,
-and can be used to read from and write to the h5ad file format. It is
-also the main data format used in the scanpy python package (Wolf,
-Angerer, and Theis 2018).
+> **⚠️ This package is superseded by
+> [anndataR](https://anndataR.scverse.org).**
+>
+> `anndataR` provides a pure R implementation of the `AnnData` data
+> structure — no Python required. It reads and writes `.h5ad` files
+> natively and supports conversion to/from `SingleCellExperiment` and
+> `Seurat` objects. New users should install `anndataR` from
+> Bioconductor instead:
+>
+> ``` r
+> BiocManager::install("anndataR")
+> ```
+>
+> Existing users of `anndata` can follow the [migration
+> guide](https://anndata.dynverse.org/articles/migration_to_anndataR.html)
+> for guidance on switching to `anndataR`.
 
-![](https://raw.githubusercontent.com/dynverse/anndata/master/man/readme_files/anndata_for_r.png)
-
-However, using scanpy/anndata in R can be a major hassle. When trying to
-read an h5ad file, R users could approach this problem in one of two
-ways. A) You could read in the file manually (since it’s an H5 file),
-but this involves a lot of manual work and a lot of understanding on how
-the h5ad and H5 file formats work (also, expect major headaches from
-cryptic hdf5r bugs). Or B) interact with scanpy and anndata through
-reticulate, but run into issues converting some of the python objects
-into R.
-
-We recently published
-[`anndata`](https://cran.r-project.org/package=anndata) on CRAN, which
-is a reticulate wrapper for the Python package – with some syntax
-sprinkled on top to make R users feel more at home.
-
-anndata for R is still under active development at
-[github.com/dynverse/anndata](https://github.com/dynverse/anndata). If
-you encounter any issues, feel free to post an issue on GitHub!
+`anndata` for R is a `reticulate` wrapper for the Python `anndata`
+package.
 
 ## Installation
+
+> **Note:** New projects should use
+> [anndataR](https://anndataR.scverse.org) instead. See
+> the [migration
+> guide](https://anndata.dynverse.org/articles/migration_to_anndataR.html).
 
 You can install `anndata` for R from CRAN as follows:
 
@@ -62,16 +63,7 @@ is an example:
 
 ``` r
 library(anndata)
-```
 
-    ## 
-    ## Attaching package: 'anndata'
-
-    ## The following object is masked from 'package:readr':
-    ## 
-    ##     read_csv
-
-``` r
 ad <- read_h5ad("example_formats/pbmc_1k_protein_v3_processed.h5ad")
 
 ad
@@ -84,7 +76,7 @@ ad
     ##     varm: 'PCs'
 
 ``` r
-Matrix::rowMeans(ad$X[1:10,])
+Matrix::rowMeans(ad$X[1:10, ])
 ```
 
     ## AAACCCAAGTGGTCAG-1 AAAGGTATCAACTACG-1 AAAGTCCAGCGTGTCC-1 AACACACTCAAGAGTA-1 
@@ -98,29 +90,17 @@ See `?anndata` for a full list of the functions provided by this
 package. Check out any of the other vignettes by clicking any of the
 links below:
 
--   [Getting
-    started](https://anndata.dynverse.org/articles/getting_started.html)
--   [Demo with
-    scanpy](https://anndata.dynverse.org/articles/scanpy_demo.html)
+- [Getting
+  started](https://anndata.dynverse.org/articles/getting_started.html)
+- [Migrating from anndata to
+  anndataR](https://anndata.dynverse.org/articles/migration_to_anndataR.html)
+- [Demo with
+  scanpy](https://anndata.dynverse.org/articles/scanpy_demo.html)
 
 ## Future work
 
-In some cases, this package may still act more like a Python package
-rather than an R package. Some more helper functions and helper classes
-need to be defined in order to fully encapsulate `AnnData()` objects.
-Examples are `ad$chunked_X(...)`, backed file modes, `read_zarr()` and
-`ad$write_zarr()`.
+This package is no longer under active development as it has been
+superseded by [anndataR](https://anndataR.scverse.org).
+Bug fixes may still be applied, but no new features are planned.
 
 ## References
-
-<div id="refs" class="references csl-bib-body hanging-indent">
-
-<div id="ref-wolf_scanpylargescalesinglecell_2018" class="csl-entry">
-
-Wolf, F Alexander, Philipp Angerer, and Fabian J Theis. 2018. “SCANPY:
-Large-Scale Single-Cell Gene Expression Data Analysis.” *Genome Biology*
-19 (February): 15. <https://doi.org/10.1186/s13059-017-1382-0>.
-
-</div>
-
-</div>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ superseded](https://img.shields.io/badge/lifecycle-superseded-blue.svg)](https:/
 > [anndataR](https://anndataR.scverse.org).**
 >
 > `anndataR` provides a pure R implementation of the `AnnData` data
-> structure — no Python required. It reads and writes `.h5ad` files
+> structure with no Python required. It reads and writes `.h5ad` files
 > natively and supports conversion to/from `SingleCellExperiment` and
 > `Seurat` objects. New users should install `anndataR` from
 > Bioconductor instead:
@@ -36,8 +36,7 @@ package.
 ## Installation
 
 > **Note:** New projects should use
-> [anndataR](https://anndataR.scverse.org) instead. See
-> the [migration
+> [anndataR](https://anndataR.scverse.org) instead. See the [migration
 > guide](https://anndata.dynverse.org/articles/migration_to_anndataR.html).
 
 You can install `anndata` for R from CRAN as follows:
@@ -100,7 +99,7 @@ links below:
 ## Future work
 
 This package is no longer under active development as it has been
-superseded by [anndataR](https://anndataR.scverse.org).
-Bug fixes may still be applied, but no new features are planned.
+superseded by [anndataR](https://anndataR.scverse.org). Bug fixes may
+still be applied, but no new features are planned.
 
 ## References

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,12 +4,13 @@ home:
   links:
     - text: Python package
       href: "https://anndata.readthedocs.io"
+    - text: Superseded by anndataR
+      href: "https://anndataR.scverse.org"
 
 template:
   bootstrap: 5
   params:
     ganalytics: "G-XSL8ZZLBFK"
-
 
 reference:
  - title: Package documentation
@@ -52,4 +53,3 @@ reference:
    - all.equal.AnnDataR6
    - names.LayersR6
    - r-py-conversion
-

--- a/man/AnnData.Rd
+++ b/man/AnnData.Rd
@@ -113,6 +113,14 @@ AnnDatas always have two inherent dimensions, \code{obs} and \code{var}.
 Additionally, maintaining the dimensionality of the AnnData object allows for
 consistent handling of \code{scipy.sparse} matrices and \code{numpy} arrays.
 }
+\section{Superseded}{
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+This function is superseded by \href{https://anndataR.scverse.org/reference/AnnData.html}{\code{anndataR::AnnData()}}
+in the \href{https://anndataR.scverse.org}{anndataR} package.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- AnnData(

--- a/man/anndata-package.Rd
+++ b/man/anndata-package.Rd
@@ -6,18 +6,29 @@
 \alias{anndata}
 \title{anndata - Annotated Data}
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+}
+\details{
+\strong{This package is superseded by \href{https://anndataR.scverse.org}{anndataR}.}
+\code{anndataR} provides a pure R implementation of the \code{AnnData} data structure
+with native \code{h5ad} file reading/writing and conversion to/from
+\code{SingleCellExperiment} and \code{Seurat} objects. Please consider migrating;
+see \code{vignette("migration_to_anndataR", package = "anndata")} for guidance.
+
+If you already have Python \code{anndata} installed, \code{anndataR}'s \code{ReticulateAnnData}
+backend lets you keep using your existing Python environment while gaining access
+to \code{anndataR}'s unified interface. The native \code{InMemoryAnnData} and \code{HDF5AnnData}
+backends (no Python required) are preferred for new workflows.
+
 \code{anndata} provides a scalable way of keeping track of data
 and learned annotations, and can be used to read from and write to the h5ad
 file format. \code{AnnData()} stores a data matrix \code{X} together with annotations
 of observations \code{obs} (\code{obsm}, \code{obsp}), variables \code{var} (\code{varm}, \code{varp}),
 and unstructured annotations \code{uns}.
-}
-\details{
-This package is, in essense, an R wrapper for the similarly named Python package
+
+This package is an R wrapper for the similarly named Python package
 \href{https://anndata.readthedocs.io/en/latest/}{\code{anndata}}, with some added functionality
 to support more R-like syntax.
-The version number of the anndata R package is synced
-with the version number of the python version.
 
 Check out \code{?anndata} for a full list of the functions provided by this package.
 }

--- a/man/concat.Rd
+++ b/man/concat.Rd
@@ -39,6 +39,7 @@ concat(
 \item{pairwise}{Whether pairwise elements along the concatenated dimension should be included. This is FALSE by default, since the resulting arrays are often not meaningful.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Concatenates AnnData objects along an axis.
 }
 \details{
@@ -48,6 +49,13 @@ warning: This function is marked as experimental for the \code{0.7} release seri
 
 warning: If you use \code{join='outer'} this fills 0s for sparse data when variables are absent in a batch. Use this with care. Dense data is filled with \code{NaN}.
 }
+\section{Superseded}{
+
+This function is superseded. The \href{https://anndataR.scverse.org}{anndataR}
+package supports working with \code{AnnData} objects natively in R without Python.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 # Preparing example objects

--- a/man/read_csv.Rd
+++ b/man/read_csv.Rd
@@ -21,11 +21,19 @@ read_csv(
 \item{dtype}{Numpy data type.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.csv} file.
 }
 \details{
 Same as \code{\link[=read_text]{read_text()}} but with default delimiter \code{','}.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_csv("matrix.csv")

--- a/man/read_excel.Rd
+++ b/man/read_excel.Rd
@@ -14,12 +14,20 @@ read_excel(filename, sheet, dtype = "float32")
 \item{dtype}{Numpy data type.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.xlsx} (Excel) file.
 }
 \details{
 Assumes that the first columns stores the row names and the first row the
 column names.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_excel("spreadsheet.xls")

--- a/man/read_h5ad.Rd
+++ b/man/read_h5ad.Rd
@@ -12,8 +12,17 @@ read_h5ad(filename, backed = NULL)
 \item{backed}{If \code{'r'}, load \code{~anndata.AnnData} in \code{backed} mode instead of fully loading it into memory (\code{memory} mode). If you want to modify backed attributes of the AnnData object, you need to choose \code{'r+'}.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.h5ad}-formatted hdf5 file.
 }
+\section{Superseded}{
+
+This function is superseded by \href{https://anndataR.scverse.org/reference/read_h5ad.html}{\code{anndataR::read_h5ad()}}
+in the \href{https://anndataR.scverse.org}{anndataR} package,
+which reads \code{.h5ad} files natively without requiring Python.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_h5ad("example_formats/pbmc_1k_protein_v3_processed.h5ad")

--- a/man/read_hdf.Rd
+++ b/man/read_hdf.Rd
@@ -12,11 +12,19 @@ read_hdf(filename, key)
 \item{key}{Name of dataset in the file.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.h5} (hdf5) file.
 }
 \details{
 Note: Also looks for fields \code{row_names} and \code{col_names}.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_hdf("file.h5")

--- a/man/read_loom.Rd
+++ b/man/read_loom.Rd
@@ -39,12 +39,20 @@ read_loom(
 \item{...}{Arguments to loompy.connect}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.loom}-formatted hdf5 file.
 }
 \details{
 This reads the whole file into memory. Beware that you have to explicitly state when you want to read the file as
 sparse data.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_loom("dataset.loom")

--- a/man/read_mtx.Rd
+++ b/man/read_mtx.Rd
@@ -12,8 +12,16 @@ read_mtx(filename, dtype = "float32")
 \item{dtype}{Numpy data type.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.mtx} file.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_mtx("matrix.mtx")

--- a/man/read_text.Rd
+++ b/man/read_text.Rd
@@ -23,11 +23,19 @@ from enforcing splitting at single white space \code{' '}.}
 \item{dtype}{Numpy data type.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read \code{.txt}, \code{.tab}, \code{.data} (text) file.
 }
 \details{
 Same as \code{\link[=read_csv]{read_csv()}} but with default delimiter \code{NULL}.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_text("matrix.tab")

--- a/man/read_umi_tools.Rd
+++ b/man/read_umi_tools.Rd
@@ -12,8 +12,16 @@ read_umi_tools(filename, dtype = "float32")
 \item{dtype}{Numpy data type.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 Read a gzipped condensed count matrix from umi_tools.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_umi_tools("...")

--- a/man/read_zarr.Rd
+++ b/man/read_zarr.Rd
@@ -10,8 +10,15 @@ read_zarr(store)
 \item{store}{The filename, a MutableMapping, or a Zarr storage class.}
 }
 \description{
-Read from a hierarchical Zarr array store.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- read_zarr("...")

--- a/man/write_csvs.Rd
+++ b/man/write_csvs.Rd
@@ -16,8 +16,18 @@ write_csvs(anndata, dirname, skip_data = TRUE, sep = ",")
 \item{sep}{Separator for the data}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+}
+\details{
 It is not possible to recover the full AnnData from these files. Use \code{\link[=write_h5ad]{write_h5ad()}} for this.
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- AnnData(

--- a/man/write_h5ad.Rd
+++ b/man/write_h5ad.Rd
@@ -25,9 +25,20 @@ Options are \code{"gzip"}, \code{"lzf"} or \code{NULL}.}
 \item{as_dense}{Sparse in AnnData object to write as dense. Currently only supports \code{"X"} and \code{"raw/X"}.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+}
+\details{
 Generally, if you have sparse data that are stored as a dense matrix, you can
 dramatically improve performance and reduce disk space by converting to a csr_matrix:
 }
+\section{Superseded}{
+
+This function is superseded by \href{https://anndataR.scverse.org/reference/write_h5ad.html}{\code{anndataR::write_h5ad()}}
+in the \href{https://anndataR.scverse.org}{anndataR} package,
+which writes \code{.h5ad} files natively without requiring Python.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- AnnData(

--- a/man/write_loom.Rd
+++ b/man/write_loom.Rd
@@ -14,8 +14,15 @@ write_loom(anndata, filename, write_obsm_varm = FALSE)
 \item{write_obsm_varm}{Whether or not to also write the varm and obsm.}
 }
 \description{
-Write .loom-formatted hdf5 file.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- AnnData(

--- a/man/write_zarr.Rd
+++ b/man/write_zarr.Rd
@@ -14,8 +14,15 @@ write_zarr(anndata, store, chunks = NULL)
 \item{chunks}{Chunk shape.}
 }
 \description{
-Write a hierarchical Zarr array store.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 }
+\section{Superseded}{
+
+This function is superseded. Please use \href{https://anndataR.scverse.org}{anndataR}
+for reading and working with \code{AnnData} objects in R.
+See \code{vignette("migration_to_anndataR", package = "anndata")} for migration guidance.
+}
+
 \examples{
 \dontrun{
 ad <- AnnData(

--- a/vignettes/migration_to_anndataR.Rmd
+++ b/vignettes/migration_to_anndataR.Rmd
@@ -1,0 +1,178 @@
+---
+title: "Migrating from anndata to anndataR"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Migrating from anndata to anndataR}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+```{r check_on_cran, message=FALSE, warning=FALSE, echo=FALSE}
+on_cran <- !identical(Sys.getenv("NOT_CRAN"), "true")
+
+if (on_cran) {
+  knitr::opts_chunk$set(eval = FALSE)
+  knitr::asis_output(paste0(
+    "<span style=\"color: red;\">**Note:** The outputs of this vignette are not rendered on CRAN due to package size limitations. ",
+    "Please check the [Migration to anndataR](https://anndata.dynverse.org/articles/migration_to_anndataR.html) ",
+    "vignette in the package documentation.</span>"
+  ))
+}
+```
+
+## Why migrate?
+
+The `anndata` R package (this package) is superseded by
+[anndataR](https://anndataR.scverse.org), available on Bioconductor.
+
+| Feature | `anndata` (CRAN) | `anndataR` (Bioconductor) |
+|---|---|---|
+| **Python dependency** | Required | Optional (only needed for `ReticulateAnnData`) |
+| **h5ad I/O** | Via Python | Native R via `rhdf5` (preferred), or via Python reticulate |
+| **In-memory backend** | Python-backed | Native R (`InMemoryAnnData`) |
+| **HDF5-backed backend** | Python-backed | Native R (`HDF5AnnData`) |
+| **Reticulate-backed backend** | Always | Optional (`ReticulateAnnData`) |
+| **Seurat interop** | Not supported | `as_Seurat()` / `as_AnnData()` |
+| **SingleCellExperiment interop** | Not supported | `as_SingleCellExperiment()` / `as_AnnData()` |
+| **Distribution** | CRAN | Bioconductor |
+
+The preferred backends (`InMemoryAnnData`, `HDF5AnnData`) require no Python.
+For users who already have Python `anndata` installed, the `ReticulateAnnData`
+backend offers a low-friction starting point; see
+[below](#using-reticulateanndata-as-a-stepping-stone).
+
+## Installation
+
+```{r install}
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+  install.packages("BiocManager")
+}
+BiocManager::install("anndataR")
+
+# Required for native h5ad reading/writing:
+BiocManager::install("rhdf5")
+
+# Optional: SingleCellExperiment conversion
+BiocManager::install("SingleCellExperiment")
+
+# Optional: Seurat conversion
+install.packages("SeuratObject")
+```
+
+## Side-by-side migration guide
+
+### Creating an AnnData object
+
+The `AnnData()` constructor is identical in both packages. The only difference
+is that `anndataR` returns an `InMemoryAnnData` (a pure-R object) whereas
+`anndata` returned an `AnnDataR6` wrapping a Python object.
+
+```{r create}
+library(anndataR)
+
+ad <- AnnData(
+  X = matrix(1:6, nrow = 2),
+  obs = data.frame(group = c("a", "b"), row.names = c("s1", "s2")),
+  var = data.frame(type = c(1L, 2L, 3L), row.names = c("var1", "var2", "var3")),
+  layers = list(spliced = matrix(4:9, nrow = 2)),
+  uns = list(a = 1)
+)
+```
+
+### Reading and writing h5ad files
+
+The function signatures are identical. `anndataR` reads natively without Python.
+
+```{r read-write}
+# Reading
+ad <- read_h5ad("path/to/file.h5ad")                               # InMemoryAnnData (default)
+ad <- read_h5ad("path/to/file.h5ad", as = "HDF5AnnData")           # disk-backed, low memory
+sce <- read_h5ad("path/to/file.h5ad", as = "SingleCellExperiment")
+obj <- read_h5ad("path/to/file.h5ad", as = "Seurat")
+
+# Writing (works identically to anndata)
+write_h5ad(ad, "path/to/output.h5ad")
+```
+
+### Slot access and subsetting
+
+Both packages use the same `$` notation and bracket subsetting syntax.
+
+```{r slots}
+ad$X; ad$obs; ad$var; ad$obsm; ad$varm; ad$obsp; ad$varp; ad$layers; ad$uns
+
+# Subsetting returns an AnnDataView (native R) rather than a Python-backed view
+subset <- ad[1:5, ]
+subset <- ad[, c("var1", "var2")]
+subset <- ad[ad$obs$group == "a", ]
+concrete <- subset$as_InMemoryAnnData()  # materialise to a concrete object
+```
+
+### Interoperability (new in anndataR)
+
+```{r interop}
+# AnnData <-> SingleCellExperiment
+sce <- ad$as_SingleCellExperiment()
+ad  <- as_AnnData(sce)
+
+# AnnData <-> Seurat
+obj <- ad$as_Seurat()
+ad  <- as_AnnData(obj)
+```
+
+### Using ReticulateAnnData as a stepping stone
+
+`anndataR`'s `ReticulateAnnData` backend wraps a Python `anndata.AnnData` object
+via reticulate, implementing the same `AbstractAnnData` interface as the native
+backends. This is the closest equivalent to the old `anndata` R package: you can
+call Python tools (e.g. `scanpy`) on the object while also using all `anndataR`
+slot accessors from R.
+
+```{r reticulate}
+library(reticulate)
+library(anndataR)
+
+# Make scanpy available in the same Python environment that reticulate uses
+py_require("scanpy")
+sc <- import("scanpy")
+
+# Read data with scanpy
+# Note: anndataR will automatically wrap the resulting Python object in a ReticulateAnnData
+url <- "https://cf.10xgenomics.com/samples/cell-exp/6.0.0/SC3_v3_NextGem_DI_CellPlex_CSP_DTC_Sorted_30K_Squamous_Cell_Carcinoma/SC3_v3_NextGem_DI_CellPlex_CSP_DTC_Sorted_30K_Squamous_Cell_Carcinoma_count_sample_feature_bc_matrix.h5"
+ad <- sc$read_10x_h5("dataset.h5", backup_url = url)
+
+# Use anndataR slot accessors from R
+dim(ad)
+head(ad$obs)
+rowMeans(ad$X[1:10, ])
+
+# Pass back to scanpy for preprocessing
+# Note: anndataR automatically unwraps the Python object when calling scanpy functions.
+sc$pp$filter_cells(ad, min_genes = 200L)
+sc$pp$filter_genes(ad, min_cells = 3L)
+sc$pp$normalize_per_cell(ad)
+sc$pp$log1p(ad)
+
+# Write from R when done
+write_h5ad(ad, "path/to/output.h5ad")
+
+# Migrate to a different anndataR backend
+ad_mem <- ad$as_InMemoryAnnData()
+# ad_hdf5 <- ad$as_HDF5AnnData(path = "path/to/disk_backed.h5ad")
+# sce <- ad$as_SingleCellExperiment()
+# seu <- ad$as_Seurat()
+```
+
+## Getting help with anndataR
+
+- Documentation: <https://anndataR.scverse.org>
+- Vignettes: `browseVignettes("anndataR")`
+- Issue tracker: <https://github.com/scverse/anndataR/issues>


### PR DESCRIPTION
anndata for R is superseded by [anndataR](https://anndataR.scverse.org)